### PR TITLE
회피기동 조건을 변경했습니다

### DIFF
--- a/self_drive/src/self_drive.py
+++ b/self_drive/src/self_drive.py
@@ -15,12 +15,12 @@ class SelfDrive:
         turtle_vel = Twist()
         # 전진 속도 및 회전 속도 지정
         if scan.ranges[0] < 0.25:
-            turtle_vel.linear.x = 0.0  
+            turtle_vel.linear.x = 0.0
             turtle_vel.angular.z = 0.0
-        elif scan.ranges[30] < 0.25:
+        elif scan.ranges[0] < 0.25 and scan.ranges[30] < 0.25:
             turtle_vel.linear.x = 0.0  
             turtle_vel.angular.z = -2
-        elif scan.ranges[330] < 0.25:
+        elif scan.ranges[0] < 0.25 and scan.ranges[330] < 0.25:
             turtle_vel.linear.x = 0.0  
             turtle_vel.angular.z = 2
        


### PR DESCRIPTION
### 기존
- scan.ranges[30] < 0.25일때 -> turn right
- scan ranges[330] < 0.25일때 -> turn left
- 문제점 : 정면에 장애물이 없어도 앞으로 직진하지 못함

### 수정 후
- scan.ranges[0] < 0.25 and scan.ranges[30] < 0.25 -> turn right
- scan.ranges[0] < 0.25 and scan.ranges[330] < 0.25 -> turn left
- 해결 후 : 정면에 장애물이 없을때는 앞으로 직진 가능